### PR TITLE
Changes in RFL format for Frontiers

### DIFF
--- a/docs/tools/hedgehog-engine/rangers/files/rfl.md
+++ b/docs/tools/hedgehog-engine/rangers/files/rfl.md
@@ -1,7 +1,7 @@
 ---
-description: RFL tools for Sonic Generations
+description: RFL tools for Sonic Frontiers
 ---
-# XNCP Tools
+# RFL Tools
 
 ## 010 Editor
 Allows editing various file formats. Frontiers RFL files are supported through the use of specific templates.


### PR DESCRIPTION
Changed "RFL tools for Sonic Generations" to "RFL tools for Sonic Frontiers"
Changed "XNCP Tools" to "RFL Tools"