### PR TITLE
Fix for material guide

### DIFF
--- a/docs/guides/hedgehog-engine/rangers/materials/advanced-mats.md
+++ b/docs/guides/hedgehog-engine/rangers/materials/advanced-mats.md
@@ -21,7 +21,7 @@ This guide expects you to have a model that loads ingame and 5 texture maps for 
 - A `Metallic` Map *(if you do not want this make a solid `0` texture)*
 - A `f0 Specular` Map *(if you do not want this make a solid `0.25` texture)*
 - A `Roughness` Map *(if you do not want this make a solid `0.8` texture)*
-- A `DirectX Normal` Map *(if you do not want this make a solid `1, 1, 0.5` texture)*
+- A `DirectX Normal` Map *(if you do not want this make a solid `0.5, 0.5, 1` texture)*
 
 ![](./assets/advanced-mats/01-textures.png)
 


### PR DESCRIPTION
My dumbass wrote that the default normal map should be 1,1,0.5 when it should be 0.5,0.5,1
Only modified file should be advanced-mats.md