### PR TITLE
(Sonic Forces) Level ID Map

### DIFF
--- a/docs/docs/hedgehog-engine/wars/levels/ids.md
+++ b/docs/docs/hedgehog-engine/wars/levels/ids.md
@@ -50,53 +50,68 @@ Character Index | Character
 !!! note
     The Secret and Extra stages don't use this value to indicate character.
 
-### Stages
+### Main Stages
 
-Stage Name  		 | Level ID
--------------------- | -----------
-Lost Valley          | w5a01
-Space Port           | w2a02
-Ghost Town           | w3a04
-Prison Hall          | w1a02
-VS. Zavok            | w1b01
-Egg Gate             | w1a01
-Arsenal Pyramid      | w5a03
-Luminous Forest      | w4a01
-VS. Infinite         | w4b01
-Green Hill           | w5a04
-VS. Eggman           | w5b01
-Park Avenue          | w3a02
-Casino Forest        | w4a04
-Aqua Road            | w4a02
-Sunset Heights       | w3a01
-Capital City         | w6a02
-VS. Infinite         | w6b01
-Chemical Plant       | w2a04
-Red Gate Bridge      | w3a03
-Guardian Rock        | w5a02
-Network Terminal     | w2a01
-Death Egg        	 | w1a04
-Metropolitan Highway | w6a01
-Null Space        	 | w6a03
-Imperial Tower       | w7a02
-Mortar Canyon        | w7a01
-VS. Infinite         | w7b01
-Iron Fortress        | w7a04
-Final Judgement      | w7a03
-VS. Death Egg Robot  | w7b02
-Fire Cannon 1        | w4x02
-Vanish Panel 1       | w3x02
-Bomb Block 1         | w5x03
-Plasma Cannon 1      | w2x02
-Laser Cannon 1       | w1x02
-Reverse Block 1      | w6x02
-Flying Pod           | w5x02
-Bomb Block 2         | w2x01
-Laser Cannon 2       | w6x01
-Reverse Block 2      | w5x01
-Vanish Panel 2       | w4x01
-Fire Cannon 2        | w3x01
-Plasma Cannon 2      | w1x01
-Enemy Territory      | w3d01
-Eggman's Facility    | w4d01
-Virtual Reality      | w5d01
+Stage Name            | Level ID
+--------------------- | -----------
+Lost Valley           | w5a01
+Space Port            | w2a02
+Ghost Town            | w3a04
+Prison Hall           | w1a02
+VS. Zavok             | w1b01
+Egg Gate              | w1a01
+Arsenal Pyramid       | w5a03
+Luminous Forest       | w4a01
+VS. Infinite          | w4b01
+Green Hill            | w5a04
+VS. Eggman            | w5b01
+Park Avenue           | w3a02
+Casino Forest         | w4a04
+Aqua Road             | w4a02
+Sunset Heights        | w3a01
+Capital City          | w6a02
+VS. Infinite          | w6b01
+Chemical Plant        | w2a04
+Red Gate Bridge       | w3a03
+Guardian Rock         | w5a02
+Network Terminal      | w2a01
+Death Egg             | w1a04
+Metropolitan Highway  | w6a01
+Null Space            | w6a03
+Imperial Tower        | w7a02
+Mortar Canyon         | w7a01
+VS. Infinite          | w7b01
+Iron Fortress         | w7a04
+Final Judgement       | w7a03
+VS. Death Egg Robot   | w7b02
+
+### Secret Stages
+
+Stage Name      | Level ID
+--------------- | -----------
+Fire Cannon 1   | w4x02
+Vanish Panel 1  | w3x02
+Bomb Block 1    | w5x03
+Plasma Cannon 1 | w2x02
+Laser Cannon 1  | w1x02
+Reverse Block 1 | w6x02
+
+### Extra Stages
+
+Stage Name      | Level ID
+--------------- | -----------
+Flying Pod      | w5x02
+Bomb Block 2    | w2x01
+Laser Cannon 2  | w6x01
+Reverse Block 2 | w5x01
+Vanish Panel 2  | w4x01
+Fire Cannon 2   | w3x01
+Plasma Cannon 2 | w1x01
+
+### Episode Shadow Stages
+
+Stage Name        | Level ID
+----------------- | -----------
+Enemy Territory   | w3d01
+Eggman's Facility | w4d01
+Virtual Reality   | w5d01

--- a/docs/docs/hedgehog-engine/wars/levels/ids.md
+++ b/docs/docs/hedgehog-engine/wars/levels/ids.md
@@ -1,0 +1,102 @@
+---
+description: Sonic Forces level ID map
+---
+
+# Level ID Map
+
+## Mapping
+Stage IDs are defined like this:
+```
+{world_id}{stage_type}{character_index}
+```
+!!! info "Example"
+    w5a01 -> Lost Valley
+
+### Worlds (Zones)
+
+World ID | World Name
+-------- | -----------
+w1       | Death Egg
+w2       | Chemical Plant
+w3       | City
+w4       | Mystic Jungle
+w5       | Green Hill
+w6       | Metropolis
+w7       | Eggman Empire Fortress
+
+### Stage Type
+
+Stage Type ID | Stage Type
+------------- | -----------
+a             | Act
+b             | Boss
+d             | DLC
+s             | Credits
+t             | Title
+x             | Extra
+
+### Character Index
+
+Character Index | Character
+--------------- | ----------
+01              | Modern Sonic
+02              | Avatar
+03              | Tag Team
+04              | Classic Sonic
+
+!!! note
+    Bosses don't use this value to indicate character, rather as a boss index for the current world (which only comes up in World 7).
+
+!!! note
+    The Secret and Extra stages don't use this value to indicate character.
+
+### Stages
+
+Stage Name  		 | Level ID
+-------------------- | -----------
+Lost Valley          | w5a01
+Space Port           | w2a02
+Ghost Town           | w3a04
+Prison Hall          | w1a02
+VS. Zavok            | w1b01
+Egg Gate             | w1a01
+Arsenal Pyramid      | w5a03
+Luminous Forest      | w4a01
+VS. Infinite         | w4b01
+Green Hill           | w5a04
+VS. Eggman           | w5b01
+Park Avenue          | w3a02
+Casino Forest        | w4a04
+Aqua Road            | w4a02
+Sunset Heights       | w3a01
+Capital City         | w6a02
+VS. Infinite         | w6b01
+Chemical Plant       | w2a04
+Red Gate Bridge      | w3a03
+Guardian Rock        | w5a02
+Network Terminal     | w2a01
+Death Egg        	 | w1a04
+Metropolitan Highway | w6a01
+Null Space        	 | w6a03
+Imperial Tower       | w7a02
+Mortar Canyon        | w7a01
+VS. Infinite         | w7b01
+Iron Fortress        | w7a04
+Final Judgement      | w7a03
+VS. Death Egg Robot  | w7b02
+Fire Cannon 1        | w4x02
+Vanish Panel 1       | w3x02
+Bomb Block 1         | w5x03
+Plasma Cannon 1      | w2x02
+Laser Cannon 1       | w1x02
+Reverse Block 1      | w6x02
+Flying Pod           | w5x02
+Bomb Block 2         | w2x01
+Laser Cannon 2       | w6x01
+Reverse Block 2      | w5x01
+Vanish Panel 2       | w4x01
+Fire Cannon 2        | w3x01
+Plasma Cannon 2      | w1x01
+Enemy Territory      | w3d01
+Eggman's Facility    | w4d01
+Virtual Reality      | w5d01

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,9 @@ nav:
       - Sonic Generations: 
         - Levels: 
           - Level ID Map: docs/hedgehog-engine/blueblur/levels/ids.md
+      - Sonic Forces: 
+        - Levels: 
+          - Level ID Map: docs/hedgehog-engine/wars/levels/ids.md
       - Sonic Frontiers:
         - DLC:
           - DLC ID Map: docs/hedgehog-engine/rangers/dlc/ids.md


### PR DESCRIPTION
Not too sure if I should list the credits stages in the actual stage list (such as w5s01), as they aren't actually playable stages and are just there to load a specific GEdit for the credits camera flybys.

Might also want to split up the stage list to three different ones for Main, Secret and Extra? If so, maybe also split the three Episode Shadow stages out too?